### PR TITLE
[feat] invalid command test 및 구현

### DIFF
--- a/shell/shell.py
+++ b/shell/shell.py
@@ -4,6 +4,16 @@ from ssd.storage_device_interface import StorageDeviceInterface
 from ssd.virtual_ssd import VirtualSSD
 
 
+ALLOWED_INITIAL_COMMANDS = [
+    "W",
+    "R",
+    "exit",
+    "help",
+    "fullwrite",
+    "fullread",
+]  # test 명령어 추가 필요
+
+
 class Validate:
     def is_valid_data(self) -> None:
         pass
@@ -30,10 +40,58 @@ class Shell:
             "  help                 - Show this help message",
         ]
 
+    def is_valid_command(self, inputs: list) -> bool:
+        if inputs[0] not in ALLOWED_INITIAL_COMMANDS:
+            return False
+
+        if len(inputs) == 1:
+            return True
+        # write
+        if inputs[0] == "W":
+            if not inputs[1].isdigit():
+                return False
+
+            if not 0 <= int(inputs[1]) <= 99:
+                return False
+
+            if len(inputs[2]) != 10:
+                return False
+
+            if inputs[2][:2] != "0x":
+                return False
+
+            for char in inputs[2][2:]:
+                if not (("0" <= char <= "9") or ("A" <= char <= "F")):
+                    return False
+
+        elif inputs[0] == "R":
+            if not inputs[1].isdigit():
+                return False
+
+            if not 0 <= int(inputs[1]) <= 99:
+                return False
+
+        elif inputs[0] == "fullwrite":
+
+            if len(inputs[1]) != 10:
+                return False
+
+            if inputs[1][:2] != "0x":
+                return False
+
+            for char in inputs[1][2:]:
+                if not (("0" <= char <= "9") or ("A" <= char <= "F")):
+                    return False
+
+        return True
+
     def run(self) -> None:
         self.is_run = True
         while self.is_run:
             inputs = input().split(" ")
+            if not self.is_valid_command(inputs):
+                print("INVALID COMMAND")
+                continue
             if inputs[0] == "ssd" and inputs[1] == "W":
                 self.write(int(inputs[2]), inputs[3])
 

--- a/shell/shell.py
+++ b/shell/shell.py
@@ -5,8 +5,8 @@ from ssd.virtual_ssd import VirtualSSD
 
 
 ALLOWED_INITIAL_COMMANDS = [
-    "W",
-    "R",
+    "write",
+    "read",
     "exit",
     "help",
     "fullwrite",
@@ -47,7 +47,7 @@ class Shell:
         if len(inputs) == 1:
             return True
         # write
-        if inputs[0] == "W":
+        if inputs[0] == "write":
             if not inputs[1].isdigit():
                 return False
 
@@ -64,7 +64,7 @@ class Shell:
                 if not (("0" <= char <= "9") or ("A" <= char <= "F")):
                     return False
 
-        elif inputs[0] == "R":
+        elif inputs[0] == "read":
             if not inputs[1].isdigit():
                 return False
 

--- a/shell/test_shell.py
+++ b/shell/test_shell.py
@@ -16,43 +16,43 @@ class TestShell(TestCase):
             self.shell.run()
             mock_print.assert_any_call("INVALID COMMAND")
 
-    @patch("builtins.input", side_effect=["W X 0x1298CDEF", "exit"])
+    @patch("builtins.input", side_effect=["write X 0x1298CDEF", "exit"])
     def test_invalid_write_command_address_not_numerical(self, mock_input):
         with patch("builtins.print") as mock_print:
             self.shell.run()
             mock_print.assert_any_call("INVALID COMMAND")
 
-    @patch("builtins.input", side_effect=["R X", "exit"])
+    @patch("builtins.input", side_effect=["read X", "exit"])
     def test_invalid_read_command_address_not_numerical(self, mock_input):
         with patch("builtins.print") as mock_print:
             self.shell.run()
             mock_print.assert_any_call("INVALID COMMAND")
 
-    @patch("builtins.input", side_effect=["W 100 0x1298CDEF", "exit"])
+    @patch("builtins.input", side_effect=["write 100 0x1298CDEF", "exit"])
     def test_invalid_write_command_address_not_in_range(self, mock_input):
         with patch("builtins.print") as mock_print:
             self.shell.run()
             mock_print.assert_any_call("INVALID COMMAND")
 
-    @patch("builtins.input", side_effect=["R 100", "exit"])
+    @patch("builtins.input", side_effect=["read 100", "exit"])
     def test_invalid_read_command_address_not_in_range(self, mock_input):
         with patch("builtins.print") as mock_print:
             self.shell.run()
             mock_print.assert_any_call("INVALID COMMAND")
 
-    @patch("builtins.input", side_effect=["W 0 1x1298CDEF", "exit"])
+    @patch("builtins.input", side_effect=["write 0 1x1298CDEF", "exit"])
     def test_invalid_write_command_data_initial_not_0x(self, mock_input):
         with patch("builtins.print") as mock_print:
             self.shell.run()
             mock_print.assert_any_call("INVALID COMMAND")
 
-    @patch("builtins.input", side_effect=["W 0 0x1298CDEF0", "exit"])
+    @patch("builtins.input", side_effect=["write 0 0x1298CDEF0", "exit"])
     def test_invalid_write_command_data_length_not_10(self, mock_input):
         with patch("builtins.print") as mock_print:
             self.shell.run()
             mock_print.assert_any_call("INVALID COMMAND")
 
-    @patch("builtins.input", side_effect=["W 0 0x1298CDEX", "exit"])
+    @patch("builtins.input", side_effect=["write 0 0x1298CDEX", "exit"])
     def test_invalid_write_command_data_not_in_hex_range(self, mock_input):
         with patch("builtins.print") as mock_print:
             self.shell.run()

--- a/shell/test_shell.py
+++ b/shell/test_shell.py
@@ -10,6 +10,72 @@ class TestShell(TestCase):
     def setUp(self):
         self.shell = Shell()
 
+    @patch("builtins.input", side_effect=["Write 3 0x1298CDEF", "exit"])
+    def test_invalid_command_not_allowed_initial_command(self, mock_input):
+        with patch("builtins.print") as mock_print:
+            self.shell.run()
+            mock_print.assert_any_call("INVALID COMMAND")
+
+    @patch("builtins.input", side_effect=["W X 0x1298CDEF", "exit"])
+    def test_invalid_write_command_address_not_numerical(self, mock_input):
+        with patch("builtins.print") as mock_print:
+            self.shell.run()
+            mock_print.assert_any_call("INVALID COMMAND")
+
+    @patch("builtins.input", side_effect=["R X", "exit"])
+    def test_invalid_read_command_address_not_numerical(self, mock_input):
+        with patch("builtins.print") as mock_print:
+            self.shell.run()
+            mock_print.assert_any_call("INVALID COMMAND")
+
+    @patch("builtins.input", side_effect=["W 100 0x1298CDEF", "exit"])
+    def test_invalid_write_command_address_not_in_range(self, mock_input):
+        with patch("builtins.print") as mock_print:
+            self.shell.run()
+            mock_print.assert_any_call("INVALID COMMAND")
+
+    @patch("builtins.input", side_effect=["R 100", "exit"])
+    def test_invalid_read_command_address_not_in_range(self, mock_input):
+        with patch("builtins.print") as mock_print:
+            self.shell.run()
+            mock_print.assert_any_call("INVALID COMMAND")
+
+    @patch("builtins.input", side_effect=["W 0 1x1298CDEF", "exit"])
+    def test_invalid_write_command_data_initial_not_0x(self, mock_input):
+        with patch("builtins.print") as mock_print:
+            self.shell.run()
+            mock_print.assert_any_call("INVALID COMMAND")
+
+    @patch("builtins.input", side_effect=["W 0 0x1298CDEF0", "exit"])
+    def test_invalid_write_command_data_length_not_10(self, mock_input):
+        with patch("builtins.print") as mock_print:
+            self.shell.run()
+            mock_print.assert_any_call("INVALID COMMAND")
+
+    @patch("builtins.input", side_effect=["W 0 0x1298CDEX", "exit"])
+    def test_invalid_write_command_data_not_in_hex_range(self, mock_input):
+        with patch("builtins.print") as mock_print:
+            self.shell.run()
+            mock_print.assert_any_call("INVALID COMMAND")
+
+    @patch("builtins.input", side_effect=["fullwrite 1x1298CDEF", "exit"])
+    def test_invalid_fullwrite_command_data_initial_not_0x(self, mock_input):
+        with patch("builtins.print") as mock_print:
+            self.shell.run()
+            mock_print.assert_any_call("INVALID COMMAND")
+
+    @patch("builtins.input", side_effect=["fullwrite 0x1298CDEF0", "exit"])
+    def test_invalid_fullwrite_command_data_length_not_10(self, mock_input):
+        with patch("builtins.print") as mock_print:
+            self.shell.run()
+            mock_print.assert_any_call("INVALID COMMAND")
+
+    @patch("builtins.input", side_effect=["fullwrite 0x1298CDEX", "exit"])
+    def test_invalid_fullwrite_command_data_not_in_hex_range(self, mock_input):
+        with patch("builtins.print") as mock_print:
+            self.shell.run()
+            mock_print.assert_any_call("INVALID COMMAND")
+
     @patch("subprocess.run")
     def test_write_command(self, mock_subprocess_run):
         address = 3


### PR DESCRIPTION
## Description
- Shell에 command가 들어왔을 때 valid test

## Changes
- STEP 1:  명령어 첫 시작이 ["ssd", "exit", "help", "fullwrite", "fullread"] 맞는지 (test app 추가 구현 되어야 함)
- STEP 2:  W, R ,fullwrite 각 케이스에 따라 invalid test



## For reviewers
- 빠진 유효성 테스트가 존재할 수도 있어서, 꼼꼼히 확인 부탁드립니다!
- test app1 ,2가 추가될 때 ALLOWED_INITIAL_COMMANDS << 요기에 추가 필요합니다!
- shell 코드 완성되면 전체적인 리팩토링 과정이 필요할 것 같습니다 (validator class로 빼기 등)
- 현재 코드상으로 test_shell 돌리면 test_fullread_command에서 아래와 같은 에러가 나는데 이유 아시는 분 계실까욤~ pandas 깔려있고 import도 문제 없는 상황입니다.
```py
import pandas as pd
ModuleNotFoundError: No module named 'pandas'
Traceback (most recent call last):
  File "C:\Users\User\PycharmProjects\pythonProject\Aut_ut_hul_project\ssd\virtual_ssd.py", line 4, in <module>
```